### PR TITLE
pytest configuration to ignore BioSimulators warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,5 @@ addopts = --doctest-modules --strict-markers
 testpaths = vivarium_tellurium
 markers =
     slow: indicates slow tests (deselect with '-m "not slow"')
+filterwarnings =
+    ignore::biosimulators_utils.warnings.BioSimulatorsWarning


### PR DESCRIPTION
If validation is on, BioSimulators will look for potential issues in SBML files. This can be quite verbose. This can be filtered out.